### PR TITLE
Fixed chain breaking bug in SimpleUpcasterChain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All Notable changes to `event-store` will be documented in this file
 
+# 1.2.1
+* Fixed bug in `SimpleUpcasterChain` that would break the chain when a registered upcaster did not support a given event.
+
 # 1.2
 
 * Added support for upcasting to multiple events

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 - [Jeroen Fiege][link-fieg]
 - [Mark van Duijker][link-mvanduijker]
 - [Marco Janssen][link-marcojanssen]
+- [Hidde Beydals][link-hiddeco]
 - [All Contributors][link-contributors]
 
 
@@ -56,3 +57,4 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 [link-fieg]: https://github.com/fieg
 [link-mvanduijker]: https://github.com/mvanduijker
 [link-marcojanssen]: https://github.com/marcojanssen
+[link-hiddeco]: https://github.com/hiddeco

--- a/src/TreeHouse/EventStore/Upcasting/SimpleUpcasterChain.php
+++ b/src/TreeHouse/EventStore/Upcasting/SimpleUpcasterChain.php
@@ -36,6 +36,8 @@ class SimpleUpcasterChain implements UpcasterInterface
             $result = [];
 
             foreach ($events as $event) {
+                $upcasted = [$event];
+
                 if ($upcaster->supports($event)) {
                     $upcasted = $upcaster->upcast($event, $context);
 
@@ -49,9 +51,9 @@ class SimpleUpcasterChain implements UpcasterInterface
 
                         $upcasted = [$upcasted];
                     }
-
-                    array_push($result, ...$upcasted);
                 }
+
+                array_push($result, ...$upcasted);
             }
 
             $events = $result;

--- a/tests/TreeHouse/EventStore/Upcasting/SimpleUpcasterChainTest.php
+++ b/tests/TreeHouse/EventStore/Upcasting/SimpleUpcasterChainTest.php
@@ -8,6 +8,7 @@ use TreeHouse\EventStore\Tests\DummyUpcaster;
 class SimpleUpcasterChainTest extends \PHPUnit_Framework_TestCase
 {
     const UUID = '04928cbb-7062-4f4a-916f-105b43c54606';
+
     /**
      * @test
      */
@@ -21,6 +22,15 @@ class SimpleUpcasterChainTest extends \PHPUnit_Framework_TestCase
         ];
 
         $upcasterChain = new SimpleUpcasterChain();
+
+        // Will always return false, validates the chain loop does not break when an upcaster does not support
+        // the given event.
+        $upcasterChain->registerUpcaster(
+            new DummyUpcaster(function (SerializedEvent $e) {
+                return false;
+            }, null)
+        );
+
         $upcasterChain->registerUpcaster(
             new DummyUpcaster(function (SerializedEvent $e) {
                 return true;


### PR DESCRIPTION
I missed a spot in my previous `SimpleUpcasterChain` PR for multi event upcasting.

This PR ensures the chain does not break when an upcaster does not support the given event by setting the event as result, if the current upcaster in the loop supports the given event it will be overwritten with the upcasted value.